### PR TITLE
password min length six

### DIFF
--- a/api/src/Entity/Person.php
+++ b/api/src/Entity/Person.php
@@ -81,6 +81,13 @@ class Person implements UserInterface
      *
      * @Groups("person:write")
      * @Assert\NotBlank(groups={"create"}, message="Veuillez renseigner un mot de passe")
+     * @Assert\Length(
+     *     groups={"create", "update"},
+     *     min = 6,
+     *     max = 50,
+     *     minMessage = "Votre mot de passe doit contenir {{ limit }} characteres minimum",
+     *     maxMessage = "Votre mot de passe doit contenir {{ limit }} characteres maximum"
+     * )
      * @SerializedName("password")
      */
     private $plainPassword;


### PR DESCRIPTION
## Why
En tant que dev, j'aimerai m'assurer que les passwords non encodés continent au minimum 6 caractères